### PR TITLE
Add initial WordPress plugin scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+
+# WordPress plugin build artifacts
+/wp-react-design-editor/vendor/

--- a/wp-react-design-editor/assets/css/frontend.css
+++ b/wp-react-design-editor/assets/css/frontend.css
@@ -1,0 +1,10 @@
+#react-design-editor-app {
+    min-height: 480px;
+    background: #f8f9fb;
+    border: 1px dashed #c3c4c7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #1d2327;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}

--- a/wp-react-design-editor/assets/js/frontend.js
+++ b/wp-react-design-editor/assets/js/frontend.js
@@ -1,0 +1,8 @@
+( function () {
+    if ( window.wp && window.wp.i18n ) {
+        const { __ } = window.wp.i18n;
+        console.info( __( 'React Design Editor frontend assets loaded.', 'react-design-editor' ) );
+    } else {
+        console.info( 'React Design Editor frontend assets loaded.' );
+    }
+} )();

--- a/wp-react-design-editor/composer.json
+++ b/wp-react-design-editor/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "react-design/react-design-editor",
+    "description": "WooCommerce product design editor and pricing engine.",
+    "type": "wordpress-plugin",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "ReactDesignEditor\\": "src/"
+        }
+    },
+    "require": {
+        "php": "^8.0"
+    }
+}

--- a/wp-react-design-editor/composer.lock
+++ b/wp-react-design-editor/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "68739ff29871158901b0bb21a4ea0bc7",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.0"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/wp-react-design-editor/react-design-editor.php
+++ b/wp-react-design-editor/react-design-editor.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name:       React Design Editor for WooCommerce
+ * Plugin URI:        https://example.com/react-design-editor
+ * Description:       Advanced product design editor and pricing engine for WooCommerce.
+ * Version:           0.1.0
+ * Author:            Your Company
+ * Author URI:        https://example.com
+ * Text Domain:       react-design-editor
+ * Domain Path:       /languages
+ * Requires at least: 6.0
+ * Requires PHP:      8.0
+ *
+ * @package ReactDesignEditor
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'RDE_PLUGIN_FILE', __FILE__ );
+define( 'RDE_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+define( 'RDE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'RDE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+} else {
+    add_action( 'admin_notices', static function () {
+        if ( current_user_can( 'activate_plugins' ) ) {
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__( 'React Design Editor for WooCommerce requires Composer dependencies to be installed.', 'react-design-editor' )
+            );
+        }
+    } );
+    return;
+}
+
+add_action( 'plugins_loaded', static function () {
+    \ReactDesignEditor\Core\Plugin::instance()->boot();
+} );
+
+register_activation_hook( __FILE__, [ '\\ReactDesignEditor\\Core\\Plugin', 'activate' ] );
+register_deactivation_hook( __FILE__, [ '\\ReactDesignEditor\\Core\\Plugin', 'deactivate' ] );

--- a/wp-react-design-editor/src/Core/Plugin.php
+++ b/wp-react-design-editor/src/Core/Plugin.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ReactDesignEditor\Core;
+
+use ReactDesignEditor\Core\Services\ServiceRegistry;
+
+/**
+ * Main plugin bootstrapper.
+ */
+class Plugin
+{
+    private static ?self $instance = null;
+
+    private ServiceRegistry $services;
+
+    private function __construct()
+    {
+        $this->services = new ServiceRegistry();
+    }
+
+    public static function instance(): self
+    {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function boot(): void
+    {
+        add_action( 'init', [ $this, 'load_textdomain' ] );
+        $this->services->register();
+    }
+
+    public function load_textdomain(): void
+    {
+        load_plugin_textdomain( 'react-design-editor', false, dirname( RDE_PLUGIN_BASENAME ) . '/languages' );
+    }
+
+    public static function activate(): void
+    {
+        // Future activation logic.
+    }
+
+    public static function deactivate(): void
+    {
+        // Future deactivation logic.
+    }
+
+    public static function uninstall(): void
+    {
+        // Future uninstall cleanup.
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/Providers/AdminServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Services/Providers/AdminServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services\Providers;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+
+class AdminServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    public function register_menu(): void
+    {
+        add_menu_page(
+            __( 'Design Editor', 'react-design-editor' ),
+            __( 'Design Editor', 'react-design-editor' ),
+            'manage_options',
+            'react-design-editor',
+            [ $this, 'render_admin_page' ],
+            'dashicons-art'
+        );
+    }
+
+    public function render_admin_page(): void
+    {
+        echo '<div class="wrap"><h1>' . esc_html__( 'React Design Editor Settings', 'react-design-editor' ) . '</h1></div>';
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/Providers/AssetsServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Services/Providers/AssetsServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services\Providers;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+
+class AssetsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        add_action( 'init', [ $this, 'register_assets' ] );
+    }
+
+    public function register_assets(): void
+    {
+        if ( ! function_exists( 'wp_register_script' ) ) {
+            return;
+        }
+
+        wp_register_script(
+            'react-design-editor-frontend',
+            RDE_PLUGIN_URL . 'assets/js/frontend.js',
+            [ 'wp-element', 'wp-i18n' ],
+            '0.1.0',
+            true
+        );
+
+        wp_register_style(
+            'react-design-editor-frontend',
+            RDE_PLUGIN_URL . 'assets/css/frontend.css',
+            [],
+            '0.1.0'
+        );
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/Providers/FrontendServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Services/Providers/FrontendServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services\Providers;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+
+class FrontendServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        add_shortcode( 'react_design_editor', [ $this, 'render_editor_shortcode' ] );
+    }
+
+    public function render_editor_shortcode( array $attributes = [] ): string
+    {
+        wp_enqueue_script( 'react-design-editor-frontend' );
+        wp_enqueue_style( 'react-design-editor-frontend' );
+
+        return '<div id="react-design-editor-app"></div>';
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/Providers/RestServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Services/Providers/RestServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services\Providers;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class RestServiceProvider extends ServiceProvider
+{
+    private const ROUTE_NAMESPACE = 'react-design-editor/v1';
+
+    public function register(): void
+    {
+        add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            self::ROUTE_NAMESPACE,
+            '/designs',
+            [
+                'methods'             => [ 'GET' ],
+                'callback'            => [ $this, 'list_designs' ],
+                'permission_callback' => [ $this, 'can_manage_designs' ],
+            ]
+        );
+    }
+
+    public function list_designs( WP_REST_Request $request ): WP_REST_Response
+    {
+        return new WP_REST_Response(
+            [
+                'data'    => [],
+                'message' => __( 'Design listing placeholder.', 'react-design-editor' ),
+            ]
+        );
+    }
+
+    public function can_manage_designs(): bool
+    {
+        return current_user_can( 'manage_woocommerce' );
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/Providers/WooCommerceServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Services/Providers/WooCommerceServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services\Providers;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+
+class WooCommerceServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        add_action( 'woocommerce_init', [ $this, 'bootstrap_woocommerce_integration' ] );
+    }
+
+    public function bootstrap_woocommerce_integration(): void
+    {
+        if ( ! function_exists( 'WC' ) ) {
+            return;
+        }
+
+        add_filter( 'woocommerce_add_cart_item_data', [ $this, 'attach_design_data' ], 10, 2 );
+    }
+
+    public function attach_design_data( array $cart_item_data, int $product_id ): array
+    {
+        if ( ! isset( $cart_item_data['react_design_editor'] ) ) {
+            $cart_item_data['react_design_editor'] = [
+                'design_id' => null,
+                'price'     => null,
+            ];
+        }
+
+        return $cart_item_data;
+    }
+}

--- a/wp-react-design-editor/src/Core/Services/ServiceRegistry.php
+++ b/wp-react-design-editor/src/Core/Services/ServiceRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ReactDesignEditor\Core\Services;
+
+use ReactDesignEditor\Core\Support\ServiceProvider;
+
+/**
+ * Simple service registry to orchestrate providers.
+ */
+class ServiceRegistry
+{
+    /**
+     * @var ServiceProvider[]
+     */
+    private array $providers = [];
+
+    public function __construct()
+    {
+        $this->providers = [
+            new \ReactDesignEditor\Core\Services\Providers\AssetsServiceProvider(),
+            new \ReactDesignEditor\Core\Services\Providers\AdminServiceProvider(),
+            new \ReactDesignEditor\Core\Services\Providers\FrontendServiceProvider(),
+            new \ReactDesignEditor\Core\Services\Providers\RestServiceProvider(),
+            new \ReactDesignEditor\Core\Services\Providers\WooCommerceServiceProvider(),
+        ];
+    }
+
+    public function register(): void
+    {
+        foreach ( $this->providers as $provider ) {
+            $provider->register();
+        }
+    }
+}

--- a/wp-react-design-editor/src/Core/Support/ServiceProvider.php
+++ b/wp-react-design-editor/src/Core/Support/ServiceProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ReactDesignEditor\Core\Support;
+
+/**
+ * Base class for plugin service providers.
+ */
+abstract class ServiceProvider
+{
+    abstract public function register(): void;
+}

--- a/wp-react-design-editor/uninstall.php
+++ b/wp-react-design-editor/uninstall.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Uninstall procedures for React Design Editor for WooCommerce.
+ *
+ * @package ReactDesignEditor
+ */
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+    return;
+}
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+\ReactDesignEditor\Core\Plugin::uninstall();


### PR DESCRIPTION
## Summary
- add a new `wp-react-design-editor` plugin skeleton with Composer-based PSR-4 autoloading
- register service providers for assets, admin UI, shortcode frontend, REST API, and WooCommerce hooks
- scaffold stub assets, REST placeholder endpoint, and admin screen while updating gitignore for vendor output

## Testing
- composer validate


------
https://chatgpt.com/codex/tasks/task_e_68cbee0ccbd8832c861b0accf50ef1e4